### PR TITLE
faster IO not using csvwriter module

### DIFF
--- a/src/print_outputs.py
+++ b/src/print_outputs.py
@@ -168,10 +168,12 @@ class PrintOutput(object):
         header = []
         header.extend(["year","doy"])
         header.extend(["%s" % (var) for var in self.print_opts])
-        
-        wr = csv.writer(self.odaily, delimiter=',', quoting=csv.QUOTE_NONE, 
-                        escapechar=' ')
-        wr.writerow(header)
-        wr.writerows(day_outputs)
+        h = ",".join ( ( "%s " for s in header ) )
+        self.odaily.write ( h+"\n" )
+        buff = "\n".join( ( \
+               ",".join( \
+               ( "%18.6G " % elemo for elemo in row)) \
+               for row in day_outputs))
+        self.odaily.write ( buff )
         self.odaily.close()
    


### PR DESCRIPTION
So, this is an implementation of a CSV writer module that might be faster than the one in default Python (does less things). It basically builds up a file in memory and then dumps it to a file. The creation process ought to be faster and memory efficient, although if the output file is very large, it could eat up a lot of RAM, but you have the data in memory anyway, and throwing some numbers in shows reasonable memory usage in practice. Try it and see whether it works. Also, feel free to change the formatter. I used %18.6G, but %g or %f might well be enough.
